### PR TITLE
fix: retain the elpi tracer context when hidden

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,9 @@ export function activate(context: vscode.ExtensionContext) {
 	const tracer = new provider.TraceProvider(context.extensionUri);
 
 	context.subscriptions.push(
-		vscode.window.registerWebviewViewProvider(provider.TraceProvider.viewType, tracer));
+		vscode.window.registerWebviewViewProvider(provider.TraceProvider.viewType, tracer, {
+			webviewOptions: {retainContextWhenHidden: true}
+		}));
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand('elpi.open', () => {


### PR DESCRIPTION
This should stop the bug where the tracer view gets reset each time a user changes the panel